### PR TITLE
a stronger version of Where2comm

### DIFF
--- a/opencood/hypes_yaml/point_pillar_cobevt.yaml
+++ b/opencood/hypes_yaml/point_pillar_cobevt.yaml
@@ -92,7 +92,7 @@ model:
       upsample_strides: [1, 2, 4]
       num_upsample_filter: [128, 128, 128]
     shrink_header:
-      kernal_size: [3]
+      kernel_size: [3]
       stride: [2]
       padding: [1]
       dim: [256]

--- a/opencood/hypes_yaml/point_pillar_fcooper.yaml
+++ b/opencood/hypes_yaml/point_pillar_fcooper.yaml
@@ -81,7 +81,7 @@ model:
       upsample_strides: [1, 2, 4]
       num_upsample_filter: [128, 128, 128]
     shrink_header:
-      kernal_size: [ 1 ]
+      kernel_size: [ 1 ]
       stride: [ 1 ]
       padding: [ 0 ]
       dim: [ 256 ]

--- a/opencood/hypes_yaml/point_pillar_v2vnet.yaml
+++ b/opencood/hypes_yaml/point_pillar_v2vnet.yaml
@@ -82,7 +82,7 @@ model:
       upsample_strides: [1, 2, 4]
       num_upsample_filter: [128, 128, 128]
     shrink_header:
-      kernal_size: [ 3 ]
+      kernel_size: [ 3 ]
       stride: [ 2 ]
       padding: [ 1 ]
       dim: [ 256 ]

--- a/opencood/hypes_yaml/point_pillar_v2xvit.yaml
+++ b/opencood/hypes_yaml/point_pillar_v2xvit.yaml
@@ -99,7 +99,7 @@ model:
       upsample_strides: [1, 2, 4]
       num_upsample_filter: [128, 128, 128]
     shrink_header:
-      kernal_size: [3]
+      kernel_size: [3]
       stride: [2]
       padding: [1]
       dim: [256]

--- a/opencood/hypes_yaml/point_pillar_where2comm.yaml
+++ b/opencood/hypes_yaml/point_pillar_where2comm.yaml
@@ -1,73 +1,72 @@
 name: point_pillar_where2comm
 root_dir: '/home/cav/data/v2xset/train'
-validate_dir: '/home/cav/data/v2xset//test'
+validate_dir: '/home/cav/data/v2xset/test'
 
 
 wild_setting:
-  async: false
+  seed: 42
+  async: False
+  async_mode: 'sim'
   async_overhead: 100
-  seed: 20
-  loc_err: false
+  loc_err: False
   xyz_std: 0.2
   ryp_std: 0.2
-  data_size: 1.06 # Mb!!
-  transmission_speed: 27 # Mbps!!
-  backbone_delay: 10 # ms
+  data_size: 1.06  # Mb
+  transmission_speed: 27  # Mbps
+  backbone_delay: 10  # ms
 
-yaml_parser: "load_point_pillar_params"
+yaml_parser: 'load_point_pillar_params'
 train_params:
-  batch_size: &batch_size 4
-  epoches: &epoches 90
+  batch_size: &batch_size 5
+  epoches: &epoches 50
   eval_freq: 1
   save_freq: 1
   max_cav: &max_cav 5
 
 fusion:
-  core_method: 'IntermediateFusionDataset' # LateFusionDataset, EarlyFusionDataset, IntermediateFusionDataset supported
-  args: []
+  core_method: 'IntermediateFusionDataset'  # LateFusionDataset, EarlyFusionDataset, IntermediateFusionDataset supported
+  args: [ ]
 
-# preprocess-related
+# Preprocess-related
 preprocess:
-  # options: BasePreprocessor, VoxelPreprocessor, BevPreprocessor
+  # Options: BasePreprocessor, VoxelPreprocessor, BevPreprocessor
   core_method: 'SpVoxelPreprocessor'
   args:
-    voxel_size: &voxel_size [0.4, 0.4, 8]
+    voxel_size: &voxel_size [ 0.4, 0.4, 4 ]
     max_points_per_voxel: 32
     max_voxel_train: 32000
     max_voxel_test: 70000
-  # lidar range for each individual cav.
-  cav_lidar_range: &cav_lidar [-140.8, -38.4, -5, 140.8, 38.4, 3]
+  # LiDAR range for each individual CAV
+  cav_lidar_range: &cav_lidar [ -140.8, -38.4, -3, 140.8, 38.4, 1 ]
 
 data_augment:
   - NAME: random_world_flip
     ALONG_AXIS_LIST: [ 'x' ]
-
   - NAME: random_world_rotation
     WORLD_ROT_ANGLE: [ -0.78539816, 0.78539816 ]
-
   - NAME: random_world_scaling
     WORLD_SCALE_RANGE: [ 0.95, 1.05 ]
 
-# anchor box related
+# Anchor box related
 postprocess:
-  core_method: 'VoxelPostprocessor' # VoxelPostprocessor, BevPostprocessor supported
+  core_method: 'VoxelPostprocessor'  # VoxelPostprocessor, BevPostprocessor supported
   anchor_args:
     cav_lidar_range: *cav_lidar
     l: 3.9
     w: 1.6
     h: 1.56
-    r: [0, 90]
-    feature_stride: 4
+    r: [ 0, 90 ]
     num: &achor_num 2
+    feature_stride: 4
   target_args:
     pos_threshold: 0.6
     neg_threshold: 0.45
-    score_threshold: 0.20
-  order: 'hwl' # hwl or lwh
-  max_num: 100 # maximum number of objects in a single frame. use this number to make sure different frames has the same dimension in the same batch
+    score_threshold: 0.2
+  order: 'hwl'  # hwl or lwh
+  max_num: 100  # Maximum number of objects in a single frame. Use this number to make sure different frames has the same dimension in the same batch
   nms_thresh: 0.15
 
-# model related
+# Model related
 model:
   core_method: point_pillar_where2comm
   args:
@@ -78,8 +77,6 @@ model:
     max_cav: *max_cav
     compression: 0  # Compression rate
     backbone_fix: False
-    keep_ego: False
-    conf_map: False
     pillar_vfe:
       use_norm: True
       with_distance: False
@@ -94,13 +91,13 @@ model:
       upsample_strides: [ 1, 2, 4 ]
       num_upsample_filter: [ 128, 128, 128 ]
     shrink_header:
-      kernal_size: [ 3 ]
+      kernel_size: [ 3 ]
       stride: [ 2 ]
       padding: [ 1 ]
       dim: [ 256 ]
       input_dim: 384  # 128 * 3
     where2comm_fusion:
-      fully: True
+      fully: False
       voxel_size: *voxel_size
       downsample_rate: 4
       in_channels: 256
@@ -108,7 +105,6 @@ model:
       layer_nums: *layer_nums
       num_filters: *num_filters
       communication:
-        activate: true
         round: 1
         threshold: 0.01
         gaussian_smooth:
@@ -123,15 +119,14 @@ loss:
 
 optimizer:
   core_method: Adam
-  lr: 0.001
+  lr: 2e-4
   args:
     eps: 1e-10
-    weight_decay: 1e-4
+    weight_decay: 1e-2
 
 lr_scheduler:
-    core_method: cosineannealwarm #step, multistep, Exponential and cosineannealwarm support
-    epoches: *epoches
-    warmup_lr: 2e-4
-    warmup_epoches: 10
-    lr_min: 2e-5
-
+  core_method: cosineannealwarm # step, multistep, exponential and cosineannealwarm support
+  epoches: *epoches
+  warmup_lr: 2e-5
+  warmup_epoches: 10
+  lr_min: 5e-6

--- a/opencood/models/fuse_modules/self_attn.py
+++ b/opencood/models/fuse_modules/self_attn.py
@@ -50,16 +50,15 @@ class AttFusion(nn.Module):
 
     def forward(self, x, record_len):
         split_x = self.regroup(x, record_len)
-        batch_size = len(record_len)
         C, W, H = split_x[0].shape[1:]
         out = []
         for xx in split_x:
             cav_num = xx.shape[0]
             xx = xx.view(cav_num, C, -1).permute(2, 0, 1)
             h = self.att(xx, xx, xx)
-            h = h.permute(1, 2, 0).view(cav_num, C, W, H)[0, ...].unsqueeze(0)
+            h = h.permute(1, 2, 0).view(cav_num, C, W, H)[0, ...]
             out.append(h)
-        return torch.cat(out, dim=0)
+        return torch.stack(out)
 
     def regroup(self, x, record_len):
         cum_sum_len = torch.cumsum(record_len, dim=0)

--- a/opencood/models/fuse_modules/where2comm_fuse.py
+++ b/opencood/models/fuse_modules/where2comm_fuse.py
@@ -3,9 +3,12 @@ Implementation of Where2comm fusion.
 """
 
 import numpy as np
+import random
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
+
+from opencood.models.fuse_modules.self_attn import ScaledDotProductAttention
 
 
 class Communication(nn.Module):
@@ -44,57 +47,37 @@ class Communication(nn.Module):
         communication_masks = []
         communication_rates = []
         for b in range(B):
-            ori_communication_maps = batch_confidence_maps[b].sigmoid().max(dim=1, keepdim=True)[0]
-
+            ori_communication_maps, _ = batch_confidence_maps[b].sigmoid().max(dim=1, keepdim=True)
             if self.smooth:
                 communication_maps = self.gaussian_filter(ori_communication_maps)
             else:
                 communication_maps = ori_communication_maps
 
-            ones_mask = torch.ones_like(communication_maps).to(communication_maps.device)
-            zeros_mask = torch.zeros_like(communication_maps).to(communication_maps.device)
-            communication_mask = torch.where(communication_maps > self.threshold, ones_mask, zeros_mask)
+            L = communication_maps.shape[0]
+            if self.training:
+                # Official training proxy objective
+                K = int(H * W * random.uniform(0, 1))
+                communication_maps = communication_maps.reshape(L, H * W)
+                _, indices = torch.topk(communication_maps, k=K, sorted=False)
+                communication_mask = torch.zeros_like(communication_maps).to(communication_maps.device)
+                ones_fill = torch.ones(L, K, dtype=communication_maps.dtype, device=communication_maps.device)
+                communication_mask = torch.scatter(communication_mask, -1, indices, ones_fill).reshape(L, 1, H, W)
+            elif self.threshold:
+                ones_mask = torch.ones_like(communication_maps).to(communication_maps.device)
+                zeros_mask = torch.zeros_like(communication_maps).to(communication_maps.device)
+                communication_mask = torch.where(communication_maps > self.threshold, ones_mask, zeros_mask)
+            else:
+                communication_mask = torch.ones_like(communication_maps).to(communication_maps.device)
 
-            communication_rate = communication_mask[0].sum() / (H * W)
+            communication_rate = communication_mask.sum() / (L * H * W)
+            # Ego
+            communication_mask[0] = 1
 
-            communication_mask_nodiag = communication_mask.clone()
-            ones_mask = torch.ones_like(communication_mask).to(communication_mask.device)
-            communication_mask_nodiag[::2] = ones_mask[::2]
-
-            communication_masks.append(communication_mask_nodiag)
+            communication_masks.append(communication_mask)
             communication_rates.append(communication_rate)
         communication_rates = sum(communication_rates) / B
         communication_masks = torch.cat(communication_masks, dim=0)
         return communication_masks, communication_rates
-
-
-class ScaledDotProductAttention(nn.Module):
-    """
-    Scaled Dot-Product Attention proposed in 'Attention Is All You Need'.
-    Compute the dot products of the query with all keys, divide each by sqrt(dim),
-    and apply a softmax function to obtain the weights on the values.
-
-    Args:
-        dim: Dimension of attention.
-
-    Inputs:
-        query: (batch, q_len, d_model), tensor containing projection vector for decoder.
-        key: (batch, k_len, d_model), tensor containing projection vector for encoder.
-        value: (batch, v_len, d_model), tensor containing features of the encoded input sequence.
-
-    Returns:
-        context: tensor containing the context vector from attention mechanism.
-    """
-
-    def __init__(self, dim):
-        super(ScaledDotProductAttention, self).__init__()
-        self.sqrt_dim = np.sqrt(dim)
-
-    def forward(self, query, key, value):
-        score = torch.bmm(query, key.transpose(1, 2)) / self.sqrt_dim
-        attn = F.softmax(score, -1)
-        context = torch.bmm(attn, value)
-        return context
 
 
 class AttentionFusion(nn.Module):
@@ -135,7 +118,6 @@ class Where2comm(nn.Module):
             self.fuse_modules = AttentionFusion(args['in_channels'])
 
         self.naive_communication = Communication(args['communication'])
-        self.communication = args['communication']['activate']
 
     def regroup(self, x, record_len):
         cum_sum_len = torch.cumsum(record_len, dim=0)
@@ -166,7 +148,9 @@ class Where2comm(nn.Module):
 
                 # 1. Communication (mask the features)
                 if i == 0:
-                    if self.communication:
+                    if self.fully:
+                        communication_rates = torch.tensor(1).to(x.device)
+                    else:
                         # Prune
                         batch_confidence_maps = self.regroup(psm_single, record_len)
                         communication_masks, communication_rates = self.naive_communication(batch_confidence_maps, B)
@@ -174,10 +158,8 @@ class Where2comm(nn.Module):
                             communication_masks = F.interpolate(communication_masks, size=(x.shape[-2], x.shape[-1]),
                                                                 mode='bilinear', align_corners=False)
                         x = x * communication_masks
-                    else:
-                        communication_rates = torch.tensor(0).to(x.device)
 
-                # 2. Split the confidence map
+                # 2. Split the features
                 # split_x: [(L1, C, H, W), (L2, C, H, W), ...]
                 # For example [[2, 256, 48, 176], [1, 256, 48, 176], ...]
                 batch_node_features = self.regroup(x, record_len)
@@ -203,19 +185,19 @@ class Where2comm(nn.Module):
             if len(backbone.deblocks) > self.num_levels:
                 x_fuse = backbone.deblocks[-1](x_fuse)
         else:
-            # 1. Split the features
-            # split_x: [(L1, C, H, W), (L2, C, H, W), ...]
-            # For example [[2, 256, 48, 176], [1, 256, 48, 176], ...]
-            batch_node_features = self.regroup(x, record_len)
-
-            # 2. Communication (mask the features)
-            if self.communication:
+            # 1. Communication (mask the features)
+            if self.fully:
+                communication_rates = torch.tensor(1).to(x.device)
+            else:
                 # Prune
                 batch_confidence_maps = self.regroup(psm_single, record_len)
                 communication_masks, communication_rates = self.naive_communication(batch_confidence_maps, B)
-                batch_node_features = batch_node_features * communication_masks
-            else:
-                communication_rates = torch.tensor(0).to(x.device)
+                x = x * communication_masks
+
+            # 2. Split the features
+            # split_x: [(L1, C, H, W), (L2, C, H, W), ...]
+            # For example [[2, 256, 48, 176], [1, 256, 48, 176], ...]
+            batch_node_features = self.regroup(x, record_len)
 
             # 3. Fusion
             x_fuse = []
@@ -223,5 +205,4 @@ class Where2comm(nn.Module):
                 neighbor_feature = batch_node_features[b]
                 x_fuse.append(self.fuse_modules(neighbor_feature))
             x_fuse = torch.stack(x_fuse)
-
         return x_fuse, communication_rates

--- a/opencood/models/point_pillar_where2comm.py
+++ b/opencood/models/point_pillar_where2comm.py
@@ -27,7 +27,7 @@ class PointPillarWhere2comm(nn.Module):
         else:
             self.shrink_flag = False
 
-        if args['compression'] > 0:
+        if args['compression']:
             self.compression = True
             self.naive_compressor = NaiveCompressor(256, args['compression'])
         else:
@@ -95,17 +95,16 @@ class PointPillarWhere2comm(nn.Module):
 
         # Compressor
         if self.compression:
+            # The ego feature is also compressed
             spatial_features_2d = self.naive_compressor(spatial_features_2d)
 
         if self.multi_scale:
+            # Bypass communication cost, communicate at high resolution, neither shrink nor compress
             fused_feature, communication_rates = self.fusion_net(batch_dict['spatial_features'],
                                                                  psm_single,
                                                                  record_len,
                                                                  pairwise_t_matrix,
                                                                  self.backbone)
-            # Down-sample feature to reduce memory
-            if self.shrink_flag:
-                fused_feature = self.shrink_conv(fused_feature)
         else:
             fused_feature, communication_rates = self.fusion_net(spatial_features_2d,
                                                                  psm_single,

--- a/opencood/models/sub_modules/downsample_conv.py
+++ b/opencood/models/sub_modules/downsample_conv.py
@@ -33,7 +33,7 @@ class DownsampleConv(nn.Module):
         self.layers = nn.ModuleList([])
         input_dim = config['input_dim']
 
-        for (ksize, dim, stride, padding) in zip(config['kernal_size'],
+        for (ksize, dim, stride, padding) in zip(config['kernel_size'],
                                                  config['dim'],
                                                  config['stride'],
                                                  config['padding']):


### PR DESCRIPTION
This version should have stronger performance. I don't remember the best configutation, but here are some configurations can be tried to see how it goes:
- Set **where2comm_fusion.fully** to **True** during training and **False** during inference (pruning the communication graph by a pre-defined threshold)
- Set **where2comm_fusion.fully** to **False** during training (random sampling communication ratios, I haven't implemented the incremental learning as the original paper)
- Set **where2comm_fusion.multi_scale** to **False** (previous version has bugs in single-scale fusion, and I have corrected it)