### PR TITLE
Add a global sort for AP calculations

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,8 +116,9 @@ Arguments Explanation:
 - `fusion_method`: indicate the fusion strategy, currently support 'early', 'late', and 'intermediate'.
 - `show_vis`: whether to visualize the detection overlay with point cloud.
 - `show_sequence` : the detection results will visualized in a video stream. It can NOT be set with `show_vis` at the same time.
+- `global_sort_detections`: whether to globally sort detections by confidence score. If set to True, it is the mainstream AP computing method, but would increase the tolerance for FP (False Positives). **OPV2V paper does not perform the global sort.** Please choose the consistent AP calculation method in your paper for fair comparison.
 
-The evaluation results  will be dumped in the model directory.
+The evaluation results  will be dumped in the model directory. If set to True, it is the mainstream AP computing method,
 
 ## Benchmark and model zoo
 ### Results on OPV2V LiDAR-track (AP@0.7 for no-compression/ compression)

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Arguments Explanation:
 - `show_sequence` : the detection results will visualized in a video stream. It can NOT be set with `show_vis` at the same time.
 - `global_sort_detections`: whether to globally sort detections by confidence score. If set to True, it is the mainstream AP computing method, but would increase the tolerance for FP (False Positives). **OPV2V paper does not perform the global sort.** Please choose the consistent AP calculation method in your paper for fair comparison.
 
-The evaluation results  will be dumped in the model directory. If set to True, it is the mainstream AP computing method,
+The evaluation results  will be dumped in the model directory. 
 
 ## Benchmark and model zoo
 ### Results on OPV2V LiDAR-track (AP@0.7 for no-compression/ compression)

--- a/opencood/tools/inference.py
+++ b/opencood/tools/inference.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Author: Runsheng Xu <rxx3386@ucla.edu>, Hao Xiang <haxiang@g.ucla.edu>,
+# Author: Runsheng Xu <rxx3386@ucla.edu>, Hao Xiang <haxiang@g.ucla.edu>, Yifan Lu <yifan_lu@sjtu.edu.cn>
 # License: TDG-Attribution-NonCommercial-NoDistrib
 
 
@@ -37,6 +37,10 @@ def test_parser():
     parser.add_argument('--save_npy', action='store_true',
                         help='whether to save prediction and gt result'
                              'in npy_test file')
+    parser.add_argument('--global_sort_detections', action='store_true',
+                        help='whether to globally sort detections by confidence score.'
+                             'If set to True, it is the mainstream AP computing method,'
+                             'but would increase the tolerance for FP (False Positives).')
     opt = parser.parse_args()
     return opt
 
@@ -73,10 +77,11 @@ def main():
     _, model = train_utils.load_saved_model(saved_path, model)
     model.eval()
 
-    # Create the dictionary for evaluation
-    result_stat = {0.3: {'tp': [], 'fp': [], 'gt': 0},
-                   0.5: {'tp': [], 'fp': [], 'gt': 0},
-                   0.7: {'tp': [], 'fp': [], 'gt': 0}}
+    # Create the dictionary for evaluation.
+    # also store the confidence score for each prediction
+    result_stat = {0.3: {'tp': [], 'fp': [], 'gt': 0, 'score': []},                
+                   0.5: {'tp': [], 'fp': [], 'gt': 0, 'score': []},                
+                   0.7: {'tp': [], 'fp': [], 'gt': 0, 'score': []}}
 
     if opt.show_sequence:
         vis = o3d.visualization.Visualizer()
@@ -193,7 +198,8 @@ def main():
                 time.sleep(0.001)
 
     eval_utils.eval_final_results(result_stat,
-                                  opt.model_dir)
+                                  opt.model_dir,
+                                  opt.global_sort_detections)
     if opt.show_sequence:
         vis.destroy_window()
 

--- a/opencood/utils/eval_utils.py
+++ b/opencood/utils/eval_utils.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Author: Runsheng Xu <rxx3386@ucla.edu>
+# Author: Runsheng Xu <rxx3386@ucla.edu>, Yifan Lu <yifan_lu@sjtu.edu.cn>
 # License: TDG-Attribution-NonCommercial-NoDistrib
 
 
@@ -68,6 +68,7 @@ def caluclate_tp_fp(det_boxes, det_score, gt_boxes, result_stat, iou_thresh):
 
         # sort the prediction bounding box by score
         score_order_descend = np.argsort(-det_score)
+        det_score = det_score[score_order_descend] # from high to low
         det_polygon_list = list(common_utils.convert_format(det_boxes))
         gt_polygon_list = list(common_utils.convert_format(gt_boxes))
 
@@ -87,12 +88,14 @@ def caluclate_tp_fp(det_boxes, det_score, gt_boxes, result_stat, iou_thresh):
             gt_index = np.argmax(ious)
             gt_polygon_list.pop(gt_index)
 
+        result_stat[iou_thresh]['score'] += det_score.tolist()
+
     result_stat[iou_thresh]['fp'] += fp
     result_stat[iou_thresh]['tp'] += tp
     result_stat[iou_thresh]['gt'] += gt
 
 
-def calculate_ap(result_stat, iou):
+def calculate_ap(result_stat, iou, global_sort_detections):
     """
     Calculate the average precision and recall, and save them into a txt.
 
@@ -100,13 +103,29 @@ def calculate_ap(result_stat, iou):
     ----------
     result_stat : dict
         A dictionary contains fp, tp and gt number.
+        
     iou : float
+        The threshold of iou.
+
+    global_sort_detections : bool
+        Whether to sort the detection results globally.
     """
     iou_5 = result_stat[iou]
 
-    fp = iou_5['fp']
-    tp = iou_5['tp']
-    assert len(fp) == len(tp)
+    if global_sort_detections:
+        fp = np.array(iou_5['fp'])
+        tp = np.array(iou_5['tp'])
+        score = np.array(iou_5['score'])
+
+        assert len(fp) == len(tp) and len(tp) == len(score)
+        sorted_index = np.argsort(-score)
+        fp = fp[sorted_index].tolist()
+        tp = tp[sorted_index].tolist()
+        
+    else:
+        fp = iou_5['fp']
+        tp = iou_5['tp']
+        assert len(fp) == len(tp)
 
     gt_total = iou_5['gt']
 
@@ -133,12 +152,12 @@ def calculate_ap(result_stat, iou):
     return ap, mrec, mprec
 
 
-def eval_final_results(result_stat, save_path):
+def eval_final_results(result_stat, save_path, global_sort_detections):
     dump_dict = {}
 
-    ap_30, mrec_30, mpre_30 = calculate_ap(result_stat, 0.30)
-    ap_50, mrec_50, mpre_50 = calculate_ap(result_stat, 0.50)
-    ap_70, mrec_70, mpre_70 = calculate_ap(result_stat, 0.70)
+    ap_30, mrec_30, mpre_30 = calculate_ap(result_stat, 0.30, global_sort_detections)
+    ap_50, mrec_50, mpre_50 = calculate_ap(result_stat, 0.50, global_sort_detections)
+    ap_70, mrec_70, mpre_70 = calculate_ap(result_stat, 0.70, global_sort_detections)
 
     dump_dict.update({'ap30': ap_30,
                       'ap_50': ap_50,
@@ -148,7 +167,9 @@ def eval_final_results(result_stat, save_path):
                       'mpre_70': mpre_70,
                       'mrec_70': mrec_70,
                       })
-    yaml_utils.save_yaml(dump_dict, os.path.join(save_path, 'eval.yaml'))
+    
+    output_file = 'eval.yaml' if not global_sort_detections else 'eval_global_sort.yaml'
+    yaml_utils.save_yaml(dump_dict, os.path.join(save_path, output_file))
 
     print('The Average Precision at IOU 0.3 is %.2f, '
           'The Average Precision at IOU 0.5 is %.2f, '


### PR DESCRIPTION
Add a global sort of all detection samples for AP calculations.

if users add the flag `--global_sort_detections` in inference.py, it will output the global sorted AP calculation results in file `eval_global_sort.yaml`. 

Otherwise, it will output non-global sorted AP calculation results in file`eval.yaml`, which is same as the original code.